### PR TITLE
Add AI framework HTML with correct ML constructors

### DIFF
--- a/v24_framework.html
+++ b/v24_framework.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>V24 Complete PESTLE-Maxwell AI Framework - Fixed</title>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@3.11.0/dist/tf.min.js"></script>
+<script src="https://www.lactame.com/lib/ml/6.0.0/ml.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjs/12.4.2/math.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/numeric/1.2.6/numeric.min.js"></script>
+<style>
+/* minimal styles for brevity */
+body{margin:0;background:#0a0a0a;color:#e2e8f0;font-family:sans-serif;}
+.panel{background:rgba(15,23,42,0.9);border:1px solid rgba(148,163,184,0.2);border-radius:16px;padding:20px;}
+</style>
+</head>
+<body>
+<div id="ui-overlay" class="panel">
+<button onclick="trainXORNetwork()">Train XOR</button>
+<button onclick="runRegression()">Regression</button>
+<button onclick="runBayesian()">Bayesian</button>
+<button onclick="runDecisionTree()">Decision Tree</button>
+<div id="ml-results"></div>
+</div>
+<script>
+let xorModel;
+function trainXORNetwork(){
+  const data=[{input:[0,0],output:[0]},{input:[0,1],output:[1]},{input:[1,0],output:[1]},{input:[1,1],output:[0]}];
+  xorModel=new ML.NeuralNetwork({layers:[2,3,1],activation:'tanh',learningRate:0.5});
+  xorModel.train(data,{epochs:1000});
+}
+function runRegression(){
+  const features=[[0,1],[1,2],[2,3]];const labels=[0,1,2];
+  const regression=new ML.MultivariateLinearRegression(features,labels);
+  document.getElementById('ml-results').textContent='Regression ready';
+}
+function runBayesian(){
+  const nb=new ML.NaiveBayes({modelType:'Gaussian'});
+  nb.train([[0],[1],[2]],[0,1,1]);
+  document.getElementById('ml-results').textContent='Bayesian trained';
+}
+function runDecisionTree(){
+  const clf=new ML.DecisionTreeClassifier({gainFunction:'gini',maxDepth:3});
+  clf.train([[0],[1],[2]],[0,1,1]);
+  document.getElementById('ml-results').textContent='Tree trained';
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a simplified AI framework HTML demo
- use `ML.NeuralNetwork`, `ML.MultivariateLinearRegression`, `ML.NaiveBayes({modelType:'Gaussian'})`, and `ML.DecisionTreeClassifier`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874a29850d48332b3b06bb90ae370d7