### PR TITLE
Set up TensorFlow in HTML framework

### DIFF
--- a/v24_framework.html
+++ b/v24_framework.html
@@ -24,6 +24,15 @@ body{margin:0;background:#0a0a0a;color:#e2e8f0;font-family:sans-serif;}
 <div id="ml-results"></div>
 </div>
 <script>
+// Ensure TensorFlow is ready and configured
+const tfReady = (async () => {
+  if (typeof tf !== 'undefined') {
+    await tf.setBackend('webgl');
+    await tf.ready();
+    console.log('TensorFlow.js backend:', tf.getBackend());
+  }
+})();
+
 let xorModel;
 function trainXORNetwork(){
   const data=[{input:[0,0],output:[0]},{input:[0,1],output:[1]},{input:[1,0],output:[1]},{input:[1,1],output:[0]}];
@@ -31,9 +40,16 @@ function trainXORNetwork(){
   xorModel.train(data,{epochs:1000});
 }
 function runRegression(){
-  const features=[[0,1],[1,2],[2,3]];const labels=[0,1,2];
-  const regression=new ML.MultivariateLinearRegression(features,labels);
-  document.getElementById('ml-results').textContent='Regression ready';
+  tfReady.then(async () => {
+    const xs=tf.tensor2d([[0,1],[1,2],[2,3]]);
+    const ys=tf.tensor2d([[0],[1],[2]]);
+    const model=tf.sequential();
+    model.add(tf.layers.dense({units:1,inputShape:[2]}));
+    model.compile({optimizer:tf.train.sgd(0.1),loss:'meanSquaredError'});
+    await model.fit(xs,ys,{epochs:50});
+    const preds=Array.from((await model.predict(xs).data()));
+    document.getElementById('ml-results').textContent='Regression: '+preds.map(v=>v.toFixed(2)).join(', ');
+  });
 }
 function runBayesian(){
   const nb=new ML.NaiveBayes({modelType:'Gaussian'});


### PR DESCRIPTION
## Summary
- configure TensorFlow.js backend when the page loads
- implement regression using TensorFlow tensors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874f5566df8833297de28964e7ee0ce