### PR TITLE
Add TensorFlow setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,12 @@ A collection of experiments and scripts.
    ```
 
 The script will initialize a small network and display several plots demonstrating its dynamics.
+
+## TensorFlow Setup Demo
+
+A small script `tensorflow_setup.py` demonstrates initializing TensorFlow and running a matrix multiplication.
+
+Run it with:
+```bash
+python tensorflow_setup.py
+```

--- a/tensorflow_setup.py
+++ b/tensorflow_setup.py
@@ -1,0 +1,27 @@
+import tensorflow as tf
+
+
+def setup_tensorflow():
+    """Initialize TensorFlow and report available devices."""
+    gpus = tf.config.list_physical_devices('GPU')
+    print(f"TensorFlow version: {tf.__version__}")
+    if gpus:
+        print(f"GPUs detected: {len(gpus)}")
+    else:
+        print("No GPU detected. Using CPU.")
+    return gpus
+
+
+def demo_matrix_operations():
+    """Run a small matrix multiplication demo."""
+    a = tf.constant([[1.0, 2.0], [3.0, 4.0]])
+    b = tf.constant([[5.0, 6.0], [7.0, 8.0]])
+    c = tf.linalg.matmul(a, b)
+    print("Matrix A:\n", a.numpy())
+    print("Matrix B:\n", b.numpy())
+    print("A @ B:\n", c.numpy())
+
+
+if __name__ == "__main__":
+    setup_tensorflow()
+    demo_matrix_operations()


### PR DESCRIPTION
## Summary
- add `tensorflow_setup.py` with a demo matrix multiplication using TensorFlow
- document how to run the new demo in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6874f5566df8833297de28964e7ee0ce